### PR TITLE
Fix code scanning alert no. 1: URL redirection from remote source

### DIFF
--- a/idp/routes.py
+++ b/idp/routes.py
@@ -5,6 +5,7 @@ import email_validator
 from functools import wraps
 
 from flask import Blueprint, request, session, url_for, render_template, redirect, jsonify, abort
+from urllib.parse import urlparse
 from authlib.integrations.flask_oauth2 import current_token
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
@@ -68,8 +69,9 @@ def login():
 
         session['user_id'] = user.user_id
 
-        next_page = request.args.get('next')
-        if next_page:
+        next_page = request.args.get('next', '')
+        next_page = next_page.replace('\\', '')
+        if next_page and not urlparse(next_page).netloc and not urlparse(next_page).scheme:
             return redirect(next_page)
         return redirect('/')
     else:


### PR DESCRIPTION
Fixes [https://github.com/EinDev/VRChatAuth/security/code-scanning/1](https://github.com/EinDev/VRChatAuth/security/code-scanning/1)

To fix the problem, we need to validate the `next_page` parameter to ensure it does not lead to an open redirect vulnerability. The best way to do this is to check that the `next_page` URL is relative and does not contain an explicit host name. We can use the `urlparse` function from the Python standard library to parse the URL and check that the `netloc` attribute is empty. Additionally, we should handle backslashes and mistyped URLs as described in the background section.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
